### PR TITLE
Fix sport service tests

### DIFF
--- a/persistence/src/main/java/cz/fi/muni/pa165/dao/BaseDaoImpl.java
+++ b/persistence/src/main/java/cz/fi/muni/pa165/dao/BaseDaoImpl.java
@@ -2,7 +2,6 @@ package cz.fi.muni.pa165.dao;
 
 import cz.fi.muni.pa165.entity.BaseEntity;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
@@ -22,7 +21,7 @@ public abstract class BaseDaoImpl<T extends BaseEntity> implements BaseDao<T> {
 
     @Override
     public void delete(T entity) {
-        entityManager.remove(entity);
+        entityManager.remove(entityManager.contains(entity) ? entity : entityManager.merge(entity));
     }
 
     @Override

--- a/service/src/test/java/cz/muni/fi/pa165/service/SportServiceImplTest.java
+++ b/service/src/test/java/cz/muni/fi/pa165/service/SportServiceImplTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.Test;
+
 import java.util.List;
 
 @ContextConfiguration(classes = ServiceConfiguration.class)
@@ -27,6 +28,8 @@ public class SportServiceImplTest extends AbstractTestNGSpringContextTests {
         Assertions
                 .assertThat(sport)
                 .isEqualTo(load);
+
+        sportService.delete(sport); // restore the state
     }
 
     @Test
@@ -42,6 +45,7 @@ public class SportServiceImplTest extends AbstractTestNGSpringContextTests {
                 .assertThat(all)
                 .contains(sport);
 
+        sportService.delete(sport); // restore the state
     }
 
     @Test
@@ -57,13 +61,15 @@ public class SportServiceImplTest extends AbstractTestNGSpringContextTests {
                 .assertThat(all)
                 .contains(sport);
 
-//        sportService.delete(sport); // TODO deatached exception
-//
-//        all = sportService.findAll();
-//
-//        Assertions
-//                .assertThat(all)
-//                .isEmpty();
+        sportService.delete(sport); // TODO deatached exception
+
+        all = sportService.findAll();
+
+        Assertions
+                .assertThat(all)
+                .isEmpty();
+
+        sportService.delete(sport); // restore the state
     }
 
     @Test
@@ -78,6 +84,7 @@ public class SportServiceImplTest extends AbstractTestNGSpringContextTests {
         Assertions.assertThat(basketball)
                 .isNotNull()
                 .isEqualTo(sport);
-    }
 
+        sportService.delete(sport); // restore the state
+    }
 }


### PR DESCRIPTION
Pro obejití detached instance jsem použil https://stackoverflow.com/questions/17027398/java-lang-illegalargumentexception-removing-a-detached-instance-com-test-user5/17027553#17027553 .

Create metody v jednotlivých testech uchovávají instance v DB, proto jsem je vždy na konci testu zase odebral, jinak selhává test na prázdnost.